### PR TITLE
add remote

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 var electron = require('electron');
 
 //Import electron modules
-var BrowserWindow = electron.BrowserWindow; //Module to create native browser window.
+var BrowserWindow = electron.BrowserWindow || electron.remote.BrowserWindow;
 
 //Auth object
 module.exports = function(provider, opt, cb)


### PR DESCRIPTION
Had a `BrowserWindow is not a constructor`error when trying to call oauth from a renderer process.
Now using remote to use auth in a renderer process.